### PR TITLE
git-ck: Only check the relevant number of commits

### DIFF
--- a/git-ck
+++ b/git-ck
@@ -24,6 +24,9 @@
 
 STATUS = `git status`
 
+# The maximum number of commits git-ck will manage
+MANAGED_COMMIT_COUNT = 2
+
 def check_staged
   return STATUS.include?('Changes to be committed:')
 end
@@ -53,7 +56,7 @@ end
 # the staged changes are uncommited and staged. Finally the unstaged changes
 # are poped from the stash
 def uncommit
-  log = `git log`.split(/\n/)[0..1]
+  log = `git log -#{MANAGED_COMMIT_COUNT}`.split(/\n/)[0..1]
   if check_unstaged_commit(log)
     `git reset HEAD~`
     `git stash`


### PR DESCRIPTION
Currently git-ck reads the entire log when looking for commits to put
back into staged and unstaged. This is really in-efficient, and can have
odd side effects.

Fixes #7
